### PR TITLE
fixed how the buttons on the samples page work

### DIFF
--- a/core/templates/core/sample_details.html
+++ b/core/templates/core/sample_details.html
@@ -58,9 +58,7 @@
                 <li class="nav-item" role="presentation">
                     <button class="nav-link" id="{{ key }}-tab" data-bs-toggle="tab" data-bs-target="#{{ key }}-tab-pane"
                             type="button" role="tab" aria-controls="{{ key }}-tab-pane" aria-selected="false">
-                        <span class="btn btn-primary">
-                            <label for="{{ key }}-file" classs="btn btn-primary load-button p-n2">+</label>
-                        </span>
+                        <label class="btn btn-primary" for="{{ key }}-file" classs="btn btn-primary load-button">+</label>
                         {{key}}
                         <span v-if="loading.{{ key }}" class="loading">
                             <span class="spinner-border" role="status">


### PR DESCRIPTION
Previously the load button for loading samples on the samples page only worked if the user clicked directly on the plus symbol in the middle of the button. The UI has been updated so that the button works rather than just the plus symbol.